### PR TITLE
Ajout du modèle UserPreference et gestion des préférences

### DIFF
--- a/panel/app/Http/Controllers/UserPreferencesController.php
+++ b/panel/app/Http/Controllers/UserPreferencesController.php
@@ -1,1 +1,37 @@
-<?php // UserPrefsController ?>
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\UserPreference;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class UserPreferencesController extends Controller
+{
+    public function index(Request $request)
+    {
+        $user = $request->user();
+        $preferences = UserPreference::where('user_id', $user->id)
+            ->pluck('value', 'key');
+
+        return response()->json($preferences);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'key' => ['required', 'string', 'max:255'],
+            'value' => ['required', 'string'],
+        ]);
+
+        $user = $request->user();
+
+        $preference = UserPreference::updateOrCreate(
+            ['user_id' => $user->id, 'key' => $data['key']],
+            ['value' => $data['value']]
+        );
+
+        return response()->json($preference, 201);
+    }
+}
+

--- a/panel/app/Models/UserPreference.php
+++ b/panel/app/Models/UserPreference.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserPreference extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'key',
+        'value',
+    ];
+}
+

--- a/panel/database/migrations/2024_05_06_000000_create_user_preferences_table.php
+++ b/panel/database/migrations/2024_05_06_000000_create_user_preferences_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('key');
+            $table->text('value');
+            $table->timestamps();
+            $table->unique(['user_id', 'key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_preferences');
+    }
+};
+

--- a/panel/routes/api.php
+++ b/panel/routes/api.php
@@ -1,1 +1,10 @@
-<?php // Routes API ici ?>
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\UserPreferencesController;
+
+Route::middleware('auth')->group(function () {
+    Route::get('/preferences', [UserPreferencesController::class, 'index']);
+    Route::post('/preferences', [UserPreferencesController::class, 'store']);
+});
+


### PR DESCRIPTION
## Summary
- crée modèle `UserPreference` et migration associée
- implémente `UserPreferencesController` pour lire/écrire les préférences de l'utilisateur connecté avec validation stricte
- ajoute routes API protégées

## Testing
- `php -l panel/app/Http/Controllers/UserPreferencesController.php`
- `phpunit` (aucun test configuré)


------
https://chatgpt.com/codex/tasks/task_e_6891f0b66d308332b6cc935d56048220