### PR TITLE
Protect mod install endpoint with auth and validation

### DIFF
--- a/panel/app/Http/Controllers/ModsController.php
+++ b/panel/app/Http/Controllers/ModsController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class ModsController
+{
+    public function install(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'url'  => ['required', 'url'],
+            'name' => ['required', 'string'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Invalid data',
+                'errors'  => $validator->errors(),
+            ], 400);
+        }
+
+        return response()->json([
+            'message' => 'Mod installation queued',
+        ], 200);
+    }
+}
+

--- a/panel/routes/api.php
+++ b/panel/routes/api.php
@@ -1,1 +1,8 @@
-<?php // Routes API ici ?>
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ModsController;
+
+Route::middleware(['auth', 'can:manage-mods'])->group(function () {
+    Route::post('/mods/install', [ModsController::class, 'install']);
+});


### PR DESCRIPTION
## Summary
- secure mod installation route with `auth` and `can:manage-mods` middleware
- add mod installation controller with URL/name validation returning 400 on error

## Testing
- `php -l panel/routes/api.php`
- `php -l panel/app/Http/Controllers/ModsController.php`


------
https://chatgpt.com/codex/tasks/task_e_6891f0b892bc8332bb92168bdc1b3599